### PR TITLE
fix: handle YYB account runtime errors

### DIFF
--- a/MS.js
+++ b/MS.js
@@ -105,6 +105,7 @@ class Task {
         }
 
         await this.getUserInfo()
+        if (!this.customId) return
         await this.getJob()
         if (!this.isSigned) {
             await this.doSign()
@@ -174,8 +175,13 @@ class Task {
             let { data: result } = await axios.request(options)
 
             if (result?.msg === "success") {
-                this.valid = true;
-                this.customId = result?.data.resMemberInfo.memberId;
+                const memberInfo = result?.data?.memberInfo || result?.data?.resMemberInfo
+                this.customId = memberInfo?.memberId
+                this.valid = Boolean(this.customId)
+                if (!this.valid) {
+                    console.log(`账号[${this.index}] 查询个人信息失败：返回数据缺少 memberId`)
+                    return
+                }
                 console.log(`账号[${this.index}] 查询个人信息成功，积分：${result?.data?.memberInfo?.pointInfo?.point}`)
             } else {
                 console.log(`账号[${this.index}] 查询个人信息失败：${result?.msg || JSON.stringify(result)}`)

--- a/TCLXLC.js
+++ b/TCLXLC.js
@@ -149,8 +149,6 @@ class Tongcheng {
         const code = await getCode(this.serverEntry, APP.appid);
         if (!code) throw new Error("获取code失败");
 
-        console.log(parsedServer + " 获取code成功");
-
         const res = await request({
             method: "POST",
             url: "https://wx.17u.cn/wechatappapi/wxUser/login",

--- a/WRN.py
+++ b/WRN.py
@@ -5,7 +5,6 @@
 """
 薇诺娜专柜商城小程序签到脚本（YYB Go版）
 基于原版 v3.1.0 改写，适配 YYB_SERVER 格式
-import sys
 
 功能：
   1. YYB_SERVER 获取微信 code + 手机号 code
@@ -22,6 +21,7 @@ import sys
 import json
 import os
 import random
+import sys
 import time
 import traceback
 import urllib3

--- a/jyk.py
+++ b/jyk.py
@@ -26,8 +26,20 @@ BASE_URL = "https://jyk.scjyx.com"
 PAYCONFIG_ID = "2"
 
 # YYB server from env (YYB-GO standard)
-YYB_WX_SERVER = os.environ.get("YYB_SERVER", "").strip().rstrip("/")
+YYB_WX_SERVER = ""
 YYB_REFS: List[str] = []  # Empty means auto fetch all refs from YYB /accounts.
+for entry in os.environ.get("YYB_SERVER", "").splitlines():
+    entry = entry.strip()
+    if not entry:
+        continue
+    server, separator, ref = entry.rpartition("@")
+    if not separator:
+        server = entry
+    server = server.strip().rstrip("/")
+    if not YYB_WX_SERVER:
+        YYB_WX_SERVER = server
+    if separator and server == YYB_WX_SERVER and ref.strip():
+        YYB_REFS.append(ref.strip())
 
 MANUAL_ACCESS_TOKENS: List[str] = []
 


### PR DESCRIPTION
## Summary

- move `sys` out of the `WRN.py` module docstring so `sys.path` no longer raises `NameError`
- handle both `memberInfo` and `resMemberInfo` in `MS.js`, and stop the current account when `memberId` is absent
- remove the out-of-scope `parsedServer` reference from `TCLXLC.js`
- parse `YYB_SERVER` entries as `server@ref` in `jyk.py`, including multi-line account configuration

## Validation

- `python -m py_compile WRN.py jyk.py`
- `node --check MS.js`
- `node --check TCLXLC.js`
- verified `YYB_SERVER=yyb-go:8000@3\nyyb-go:8000@5` resolves to server `yyb-go:8000` and refs `3,5`
- verified the `MS.js` member lookup accepts the current `data.memberInfo.memberId` response shape