### PR TITLE
修复 DT生活与都市甜心运行错误

### DIFF
--- a/DSTX.py
+++ b/DSTX.py
@@ -49,10 +49,7 @@ if env_YYB_SERVER:
 # 无有效地址直接退出
 if len(SERVERS) == 0:
     print("❌ 未配置环境变量 YYB_SERVER")
-print("格式：地址@微信账号标识，多账号换行分隔")
-    print("192.168.31.36:8088")
-    print("192.168.31.88:8088")
-    print("192.168.31.62:8088")
+    print("格式：yyb-go:8000@账号ID或OpenID，多账号换行分隔")
     exit(1)
 
 print(f"✅ 读取到 {len(SERVERS)} 个 YYB Go 账号")
@@ -415,7 +412,16 @@ def extract_customer_uid(data) -> str | None:
 
 
 def extract_relogin_token(data) -> str | None:
-    values = find_values_by_key(data, {"reloginToken", "ReloginToken", "reLoginToken"})
+    values = find_values_by_key(
+        data,
+        {
+            "reloginToken",
+            "ReloginToken",
+            "reLoginToken",
+            "VISITORSESSION",
+            "visitorSession",
+        },
+    )
     for value in values:
         return str(value)
     return None
@@ -536,6 +542,8 @@ def find_login_info(
             "会员",
             f"识别成功 昵称={member_info['nickname']} | 积分={member_info['point']} | UID={mask_value(customer_uid)}",
         )
+    elif data.get("isLogin") is False:
+        log_warn("会员", "微信授权成功，但该微信尚未登录都市甜心会员")
     else:
         log_warn("会员", f"未识别会员：{json_preview(data)}")
 
@@ -726,7 +734,10 @@ def run_account(index: int, total: int, server: str) -> dict:
     store_id, customer_uid, visitor_uid, raw, member_info = login_by_code(server, proxies)
 
     if not store_id or not customer_uid or not visitor_uid:
-        result["error"] = f"登录识别失败，最后响应：{json_preview(raw, 800)}"
+        if isinstance(raw, dict) and raw.get("isLogin") is False:
+            result["error"] = "微信授权成功，但未登录都市甜心会员；请先在小程序同意隐私并完成会员注册/绑定"
+        else:
+            result["error"] = f"登录识别失败，最后响应：{json_preview(raw, 800)}"
         log_error("账号", result["error"])
         return result
 

--- a/DTSH.py
+++ b/DTSH.py
@@ -29,8 +29,7 @@ if env_YYB_SERVER:
 # 校验是否存在有效服务地址
 if len(CODE_URL_LIST) == 0:
     print("❌ 未配置环境变量 YYB_SERVER")
-print("格式：地址@微信账号标识，多账号换行分隔")
-    print("http://192.168.1.7:8088/login")
+    print("格式：yyb-go:8000@账号ID或OpenID，多账号换行分隔")
     exit(1)
 
 print(f"✅ 读取到 {len(CODE_URL_LIST)} 个 YYB Go 账号")
@@ -405,7 +404,19 @@ def do_sign(token, headers, proxy_config, account_name):
                 verify=False
             )
 
-        return res.json()
+        data = res.json()
+        # 部分节点会把 JSON 对象再包一层字符串，统一解析为字典。
+        for _ in range(2):
+            if not isinstance(data, str):
+                break
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                return {"msg": data, "data": {}}
+
+        if isinstance(data, dict):
+            return data
+        return {"msg": str(data), "data": {}}
     except Exception as e:
         print(f"❌ 签到异常：{str(e)}")
         return None
@@ -452,8 +463,11 @@ def run_account(code_url, index, global_proxy_config):
             }
 
         sign_msg = data.get("msg", "完成")
-        get_points = data.get("data", {}).get("points", 0)
-        sign_num = data.get("data", {}).get("sign_num", 0)
+        sign_data = data.get("data")
+        if not isinstance(sign_data, dict):
+            sign_data = {}
+        get_points = sign_data.get("points", 0)
+        sign_num = sign_data.get("sign_num", 0)
 
         # 获取用户信息
         nickname, uid, total_points = get_user_info(token, headers, proxy_config, account_name)


### PR DESCRIPTION
修复两个 Python 脚本的运行问题：

- 修复 DTSH.py 和 DSTX.py 配置提示代码的缩进错误
- DT生活兼容签到接口返回字符串化 JSON，避免对字符串调用 get
- 都市甜心兼容 Auth 新返回的 VISITORSESSION
- 都市甜心在微信未绑定会员时给出明确处理提示

验证：

- 两个脚本均通过 py_compile
- DT生活单账号实跑可正常读取签到和积分
- 都市甜心可正常获取 code、授权会话，并正确识别未绑定会员状态