### PR TITLE
修复捷停车脚本启动时的缩进错误

### DIFF
--- a/JTC.py
+++ b/JTC.py
@@ -64,8 +64,8 @@ if env_YYB_SERVER:
 # 无有效地址直接退出
 if len(SERVERS) == 0:
     print("❌ 未配置环境变量 YYB_SERVER")
-print("格式：地址@微信账号标识，多账号换行分隔")
-    print("192.168.1.21:8088")
+    print("格式：yyb-go:8000@账号ID或OpenID，多账号换行分隔")
+    print("示例：yyb-go:8000@1")
     sys.exit(1)
 
 print(f"✅ 读取到 {len(SERVERS)} 个 YYB Go 账号")


### PR DESCRIPTION
## 问题

`JTC.py` 在未配置 `YYB_SERVER` 的提示代码中存在缩进错误，Python 启动时会在第 68 行抛出 `IndentationError: unexpected indent`，导致青龙任务无法运行。

## 修复

- 恢复环境变量提示代码的正确缩进
- 将示例更新为 `yyb-go:8000@账号ID或OpenID` 的当前配置格式

## 验证

- `python -m py_compile JTC.py` 通过
- 已在青龙中实际运行，成功读取 8 个 YYB Go 账号并进入捷停车登录、签到和任务执行流程