### PR TITLE
修复浓五空会员信息、代理解析及唯品会登录流程

### DIFF
--- a/NWDJG.py
+++ b/NWDJG.py
@@ -148,14 +148,18 @@ def parse_proxy_response(text: Any) -> Dict[str, Any] | None:
     if not text:
         return None
 
+    parsed_json = False
     try:
         data = json.loads(text)
+        parsed_json = True
         proxy_obj = None
 
         if isinstance(data.get("data"), list) and data["data"]:
             proxy_obj = data["data"][0]
         elif isinstance(data.get("data"), dict):
-            proxy_obj = data["data"]
+            data_obj = data["data"]
+            proxy_list = data_obj.get("proxy_list")
+            proxy_obj = proxy_list[0] if isinstance(proxy_list, list) and proxy_list else data_obj
         elif data.get("ip") and data.get("port"):
             proxy_obj = data
         elif isinstance(data.get("result"), dict):
@@ -173,6 +177,9 @@ def parse_proxy_response(text: Any) -> Dict[str, Any] | None:
                 }
     except Exception:
         pass
+
+    if parsed_json:
+        return None
 
     if ":" in text:
         parts = text.split(":")
@@ -476,11 +483,13 @@ def run_account(index: int, total: int, server: str) -> Dict[str, Any]:
         print(f"🔍 [用户] 响应数据: {json_preview(user_info_resp, 200)}")
 
         if user_info_resp.get("code") == 0 and user_info_resp.get("data"):
-            member_data = user_info_resp["data"].get("member", {})
-            grade_data = user_info_resp["data"].get("grade", {})
+            user_data = user_info_resp["data"]
+            member_data = user_data.get("member") or {}
+            visitor_data = user_data.get("visitor") or {}
+            grade_data = user_data.get("grade") or {}
             points_balance = to_int(member_data.get("points", 0))
-            member_name = member_data.get("nick_name", "未知")
-            member_level = grade_data.get("level_name", "普通会员")
+            member_name = member_data.get("nick_name") or visitor_data.get("nick_name") or "未注册会员"
+            member_level = grade_data.get("level_name") or "普通会员"
 
             result["initialScore"] = points_balance
             result["userInfo"] = f"{member_name} {member_level} 当前积分{points_balance}"
@@ -526,7 +535,7 @@ def run_account(index: int, total: int, server: str) -> Dict[str, Any]:
 
             if sign_today_resp.get("code") == 0 and sign_today_resp.get("data"):
                 today_data = sign_today_resp["data"]
-                prize = today_data.get("prize", {})
+                prize = today_data.get("prize") or {}
                 goods_name = prize.get("goodsName", "无奖励")
                 
                 result["signMsg"] = f"签到成功 获得{goods_name} 连续{sign_days + 1}天"
@@ -551,7 +560,7 @@ def run_account(index: int, total: int, server: str) -> Dict[str, Any]:
         )
 
         if final_user_info_resp.get("code") == 0 and final_user_info_resp.get("data"):
-            member_data = final_user_info_resp["data"].get("member", {})
+            member_data = final_user_info_resp["data"].get("member") or {}
             points_balance = to_int(member_data.get("points", 0))
 
             result["finalScore"] = points_balance

--- a/NXDC.py
+++ b/NXDC.py
@@ -160,14 +160,18 @@ def parse_proxy_response(text) -> dict | None:
     if not text:
         return None
 
+    parsed_json = False
     try:
         data = json.loads(text)
+        parsed_json = True
         proxy_obj = None
 
         if isinstance(data.get("data"), list) and data["data"]:
             proxy_obj = data["data"][0]
         elif isinstance(data.get("data"), dict):
-            proxy_obj = data["data"]
+            data_obj = data["data"]
+            proxy_list = data_obj.get("proxy_list")
+            proxy_obj = proxy_list[0] if isinstance(proxy_list, list) and proxy_list else data_obj
         elif data.get("ip") and data.get("port"):
             proxy_obj = data
         elif isinstance(data.get("result"), dict):
@@ -185,6 +189,9 @@ def parse_proxy_response(text) -> dict | None:
                 }
     except Exception:
         pass
+
+    if parsed_json:
+        return None
 
     if ":" in text:
         parts = text.split(":")

--- a/WPH.js
+++ b/WPH.js
@@ -52,6 +52,7 @@ let userIdx = 1;
 
 const MINI_APP_ID = "wxe9714e742209d35f";
 const PACKAGE_VERSION = "1371";
+const MINI_APP_VERSION = "2.19.13.20260731";
 const API_KEY = "ce29a51aa5c94a318755b2529dcb8e0b";
 const HASH = "ptx26";
 const ACT_ID = "H3gRnE1Xi18=";
@@ -59,9 +60,11 @@ const SIGN_SECRET_ENC = "Ql4mW09F3urBNdzBLfK6UuRTqj22Bta7eEKTO7n5jFf9uU6FZZmcfe/
 
 const CACHE_FILE = path.join(__dirname, "token_caches", "vipshop_token_cache.json");
 try { fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true }); } catch (e) {}
-const DEFAULT_MARS_CID = process.env.vipshop_mars_cid || "104104";
+const CONFIGURED_MARS_CID = String(process.env.vipshop_mars_cid || "").trim();
 const DEFAULT_WAREHOUSE = "VIP_NH";
-const DEFAULT_AREA = "104104";
+const DEFAULT_PROVINCE = "104104";
+const DEFAULT_AREA = "104104101";
+const ACCOUNT_DELAY_MS = Math.max(1500, Number(process.env.VIPSHOP_ACCOUNT_DELAY_MS || 5000));
 
 function splitAccounts(value = "") {
   return String(value)
@@ -106,6 +109,24 @@ function sha1(text) {
 
 function md5(text) {
   return crypto.createHash("md5").update(String(text)).digest("hex");
+}
+
+// Same format as @wxnpm/wx-randcode used by the official mini program.
+function createMarsCid() {
+  const timestamp = Date.now().toString();
+  const randomHex = crypto.randomBytes(16).toString("hex");
+  let sum = [...timestamp].reduce((total, value) => total + Number(value), 0);
+  const checksumIndex = sum % 32;
+  for (let i = 0; i < randomHex.length; i++) {
+    if (i !== checksumIndex) sum += parseInt(randomHex[i], 16);
+  }
+  const checksum = (sum % 16).toString(16);
+  return `${timestamp}_${randomHex.slice(0, checksumIndex)}${checksum}${randomHex.slice(checksumIndex + 1)}`;
+}
+
+function normalizeMarsCid(value) {
+  const candidate = String(value || "").trim();
+  return /^\d{13}_[0-9a-f]{32}$/i.test(candidate) ? candidate : createMarsCid();
 }
 
 function aesDecryptBase64(text) {
@@ -184,7 +205,7 @@ class Vipshop {
     this.userId = this.account.userId || "";
     this.vipOpenid = this.account.vipOpenid || "";
     this.unionid = this.account.unionid || "";
-    this.marsCid = this.account.marsCid || DEFAULT_MARS_CID;
+    this.marsCid = this.account.marsCid || CONFIGURED_MARS_CID;
     this.cacheKey = this.openid || (this.vipOpenid ? md5(this.vipOpenid).slice(0, 16) : `account_${index}`);
   }
 
@@ -210,14 +231,14 @@ class Vipshop {
       mars_cid: this.marsCid,
       warehouse: DEFAULT_WAREHOUSE,
       fdc_area_id: DEFAULT_AREA,
-      province_id: DEFAULT_AREA,
+      province_id: DEFAULT_PROVINCE,
       wap_consumer: "A1",
       t: Math.floor(Date.now() / 1000),
       net: "WIFI",
       width: 375,
       height: 667,
       phone_model: "Windows",
-      phone_brand: "",
+      phone_brand: "microsoft",
       sys_version: "Windows 10",
       is_default_area: "1",
       app_theme_mode: "0",
@@ -307,7 +328,7 @@ class Vipshop {
     this.userId = this.userId || cached.userId || "";
     this.vipOpenid = this.vipOpenid || cached.vipOpenid || "";
     this.unionid = this.unionid || cached.unionid || "";
-    this.marsCid = this.account.marsCid || cached.marsCid || this.marsCid;
+    this.marsCid = normalizeMarsCid(this.account.marsCid || cached.marsCid || this.marsCid);
   }
 
   async getVipWechatInfo(code) {
@@ -354,13 +375,29 @@ class Vipshop {
 
   async ensureLogin() {
     this.loadCache();
+    this.saveCache({ miniAppVersion: MINI_APP_VERSION });
     if (this.token && this.userId && this.vipOpenid) {
       this.log(`使用缓存登录态 userId=${this.userId} VIP_TANK=${mask(this.token)}`);
       return;
     }
-    const code = await getWxCode(this.server);
-    if (!this.vipOpenid) await this.getVipWechatInfo(code);
-    if (!this.token || !this.userId) await this.autoLogin(code);
+
+    let code = await getWxCode(this.server);
+    if (!code) throw new Error("YYB 未返回有效 wx.login code");
+
+    // The official app performs trylogin before LiteApp/getUserInfo.
+    if (!this.token || !this.userId) {
+      await this.autoLogin(code);
+      this.saveCache({ miniAppVersion: MINI_APP_VERSION });
+    }
+    if (!this.vipOpenid) {
+      try {
+        await this.getVipWechatInfo(code);
+      } catch (firstError) {
+        code = await getWxCode(this.server);
+        if (!code) throw firstError;
+        await this.getVipWechatInfo(code);
+      }
+    }
     this.saveCache();
   }
 
@@ -441,7 +478,7 @@ async function main() {
   }
   for (let i = 0; i < accounts.length; i++) {
     await new Vipshop(accounts[i], i + 1).run();
-    if (i < accounts.length - 1) await await sleep(1500, 3000);
+    if (i < accounts.length - 1) await sleep(ACCOUNT_DELAY_MS + Math.floor(Math.random() * 2000));
   }
 }
 


### PR DESCRIPTION
## 修复内容

- 修复聚量代理 JSON 响应中 `data.proxy_list` 无法解析的问题，并避免将 JSON 错当成 `IP:端口`
- 修复浓五的酒馆接口返回 `member: null` 时触发 `NoneType.get`，未入会账号现在会继续执行并显示服务端提示
- 唯品会按官方小程序顺序先执行 `trylogin`，再补充 openid
- 为唯品会生成并持久化合法 `mars_cid`，同步区域、设备与版本参数
- 增加多账号请求间隔，并在 YYB 未返回 code 时直接给出明确错误

## 验证

- `python -m py_compile NXDC.py NWDJG.py`
- `node --check WPH.js`
- 青龙实跑奈雪：9 个账号完整结束，可用账号正常签到
- 青龙实跑浓五：7 个有效 YYB 账号完整执行，无 `NoneType` 异常；未入会账号返回“请先成为品牌会员”
- 青龙实跑唯品会：原 `third login fds limit` 消失，5 个已绑定账号正常读取签到结果

账号本身未扫码或未绑定业务会员时，继续保留服务端的原始提示，避免误报脚本错误。